### PR TITLE
fix typo in resolvers configuration file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To change output mode, pass ether `--extended` or `--simple` to DNSYO.
 
 ###Resolver list
 
-DNSYO periodically updates it's internal resolver database from this repo. The first time you run it, and once every 2 weeks, it will try to download the `resolver-list.yml` file and store it to `~/.dnsyo-resovers-list.yaml` directory. If you know of any more open DNS resolvers feel free to add them to the list.
+DNSYO periodically updates it's internal resolver database from this repo. The first time you run it, and once every 2 weeks, it will try to download the `resolver-list.yml` file and store it to `~/.dnsyo-resolvers-list.yaml` directory. If you know of any more open DNS resolvers feel free to add them to the list.
 
 By default, DNSYO will pick 500 servers at random from it's list to query. You can change this with the `--servers` or `-q` flag. If you want DNSYO to query all the servers just pass `--servers=ALL` or `-q=ALL`.
 

--- a/dnsyo/dnsyo.py
+++ b/dnsyo/dnsyo.py
@@ -77,7 +77,7 @@ class lookup(object):
                  domain,
                  recordType,
                  listLocation,
-                 listLocal='~/.dnsyo-resovers-list.yaml',
+                 listLocal='~/.dnsyo-resolvers-list.yaml',
                  expected=None,
                  maxServers='ALL',
                  maxWorkers=50,


### PR DESCRIPTION
Change ".dnsyo-resovers-list.yaml" to ".dnsyo-resolvers-list.yaml"